### PR TITLE
feat: implement backtracking

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -20,6 +20,7 @@ jobs:
   tests:
     name: "Tests"
     strategy:
+      fail-fast: false
       matrix:
         version:
           - '1'
@@ -28,4 +29,5 @@ jobs:
     uses: "SciML/.github/.github/workflows/tests.yml@v1"
     with:
       julia-version: "${{ matrix.version }}"
+      group: "all"
     secrets: "inherit"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LineSearch"
 uuid = "87fe0de2-c867-4266-b59a-2f0a94fc965b"
 authors = ["SciML"]
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/docs/src/api/native.md
+++ b/docs/src/api/native.md
@@ -12,3 +12,9 @@ NoLineSearch
 LiFukushimaLineSearch
 RobustNonMonotoneLineSearch
 ```
+
+## Backtracking Line Search
+
+```@docs
+BackTracking
+```

--- a/src/LineSearch.jl
+++ b/src/LineSearch.jl
@@ -22,6 +22,7 @@ function SciMLBase.reinit!(::AbstractLineSearchCache; kwargs...) end
 
 include("utils.jl")
 
+include("backtracking.jl")
 include("li_fukushima.jl")
 include("no_search.jl")
 include("robust_non_monotone.jl")
@@ -35,6 +36,7 @@ end
 
 export LineSearchSolution
 
+export BackTracking
 export NoLineSearch, LiFukushimaLineSearch, RobustNonMonotoneLineSearch
 export LineSearchesJL
 

--- a/src/backtracking.jl
+++ b/src/backtracking.jl
@@ -1,0 +1,159 @@
+"""
+    BackTracking(; autodiff = nothing, c_1 = 1e-4, ρ_hi = 0.5, ρ_lo = 0.1,
+        order = 3,
+        maxstep = Inf, initial_alpha = true)
+
+`BackTracking` line search algorithm based on the implementation in
+[LineSearches.jl](https://github.com/JuliaNLSolvers/LineSearches.jl).
+
+`BackTracking` specifies a backtracking line-search that uses a quadratic or cubic
+interpolant to determine the reduction in step-size.
+
+E.g., if `f(α) > f(0) + c₁ α f'(0)`, then the quadratic interpolant of
+`f(0)`, `f'(0)`, `f(α)` has a minimiser `α'` in the open interval `(0, α)`. More strongly,
+there exists a factor ρ = ρ(c₁) such that `α' ≦ ρ α`.
+
+This is a modification of the algorithm described in Nocedal Wright (2nd ed), Sec. 3.5.
+
+`autodiff` is the automatic differentiation backend to use for the line search. This is only
+used for the derivative of the objective function at the current step size. `autodiff` must
+be specified if analytic jacobian/jvp/vjp is not available.
+"""
+@concrete struct BackTracking <: AbstractLineSearchAlgorithm
+    autodiff
+    c_1
+    ρ_hi
+    ρ_lo
+    order <: Union{Val{2}, Val{3}}
+    maxstep
+    initial_alpha
+    maxiters::Int
+end
+
+function BackTracking(; autodiff = nothing, c_1 = 1e-4, ρ_hi = 0.5, ρ_lo = 0.1,
+        order::Union{Int, Val{2}, Val{3}} = 3, maxstep = Inf,
+        initial_alpha = true, maxiters::Int = 1_000)
+    order = order isa Val ? order : Val(order)
+    @assert order isa Val{2} || order isa Val{3}
+    return BackTracking(autodiff, c_1, ρ_hi, ρ_lo, order, maxstep, initial_alpha, maxiters)
+end
+
+@concrete mutable struct BackTrackingCache <: AbstractLineSearchCache
+    f
+    p
+    ϕ
+    ϕdϕ
+    alpha
+    initial_alpha
+    deriv_op
+    u_cache
+    fu_cache
+    stats <: Union{SciMLBase.NLStats, Nothing}
+    alg <: BackTracking
+    maxiters::Int
+end
+
+function CommonSolve.init(
+        prob::AbstractNonlinearProblem, alg::BackTracking, fu, u;
+        stats::Union{SciMLBase.NLStats, Nothing} = nothing, autodiff = nothing, kwargs...)
+    T = promote_type(eltype(fu), eltype(u))
+    autodiff = autodiff !== nothing ? autodiff : alg.autodiff
+
+    _, _, deriv_op = construct_jvp_or_vjp_operator(prob, fu, u; autodiff)
+
+    @bb u_cache = similar(u)
+    @bb fu_cache = similar(fu)
+
+    ϕ = @closure (f, p, u, du, α, u_cache, fu_cache) -> begin
+        @bb @. u_cache = u + α * du
+        fu_cache = evaluate_f!!(f, fu_cache, u_cache, p)
+        add_nf!(stats)
+        return @fastmath norm(fu_cache)^2 / 2
+    end
+
+    ϕdϕ = @closure (f, p, u, du, α, u_cache, fu_cache, deriv_op) -> begin
+        @bb @. u_cache = u + α * du
+        fu_cache = evaluate_f!!(f, fu_cache, u_cache, p)
+        add_nf!(stats)
+        deriv = deriv_op(du, u_cache, fu_cache, p)
+        obj = @fastmath norm(fu_cache)^2 / 2
+        return obj, deriv
+    end
+
+    u_norm = @fastmath norm(u, Inf)
+    alpha = min(alg.initial_alpha, alg.maxstep / u_norm)
+
+    return BackTrackingCache(
+        prob.f, prob.p, ϕ, ϕdϕ, T(alpha), T(alg.initial_alpha), deriv_op,
+        u_cache, fu_cache, stats, alg, alg.maxiters)
+end
+
+function CommonSolve.solve!(cache::BackTrackingCache, u, du)
+    T = promote_type(eltype(du), eltype(u))
+    ϕ = @closure α -> cache.ϕ(cache.f, cache.p, u, du, α, cache.u_cache, cache.fu_cache)
+    ϕdϕ = @closure α -> cache.ϕdϕ(
+        cache.f, cache.p, u, du, α, cache.u_cache, cache.fu_cache, cache.deriv_op)
+
+    ϕ₀, dϕ₀ = ϕdϕ(zero(T))
+    α₁, α₂ = cache.alpha, cache.alpha
+    ϕx₀, ϕx₁ = ϕ₀, ϕ(α₁)
+
+    finite_maxiters = -log2(eps(real(T)))
+    iteration = 1
+    while !isfinite(ϕx₁) && iteration ≤ finite_maxiters
+        α₁ = α₂
+        α₂ = α₁ / 2
+        ϕx₁ = ϕ(α₂)
+        iteration += 1
+    end
+
+    ϕx₁ ≤ ϕ₀ + T(cache.alg.c_1) * α₂ * dϕ₀ &&
+        return LineSearchSolution(α₂, ReturnCode.Success)
+    α_tmp = -(dϕ₀ * α₂^2) / (2 * (ϕx₁ - ϕ₀ - dϕ₀ * α₂))
+    α₁ = α₂
+    α_tmp = min(α_tmp, α₂ * T(cache.alg.ρ_hi))
+    α₂ = max(α_tmp, α₂ * T(cache.alg.ρ_lo))
+    ϕx₀, ϕx₁ = ϕx₁, ϕ(α₂)
+
+    # Backtrack until we satisfy sufficient decrease condition
+    for _ in (iteration + 1):(cache.maxiters)
+        ϕx₁ ≤ ϕ₀ + T(cache.alg.c_1) * α₂ * dϕ₀ &&
+            return LineSearchSolution(α₂, ReturnCode.Success)
+
+        α_tmp = compute_alpha_backtracking(cache.alg.order, T, dϕ₀, ϕ₀, ϕx₀, ϕx₁, α₁, α₂)
+
+        α₁ = α₂
+        α_tmp = min(α_tmp, α₂ * T(cache.alg.ρ_hi))
+        α₂ = max(α_tmp, α₂ * T(cache.alg.ρ_lo))
+
+        ϕx₀, ϕx₁ = ϕx₁, ϕ(α₂)
+    end
+
+    return LineSearchSolution(α₂, ReturnCode.Failure)
+end
+
+@inline function compute_alpha_backtracking(
+        ::Val{2}, ::Type{T}, dϕ₀, ϕ₀, _, ϕx₁, _, α₂) where {T}
+    return -(dϕ₀ * α₂^2) / (2 * (ϕx₁ - ϕ₀ - dϕ₀ * α₂))
+end
+
+@inline function compute_alpha_backtracking(
+        ::Val{3}, ::Type{T}, dϕ₀, ϕ₀, ϕx₀, ϕx₁, α₁, α₂) where {T}
+    div = inv(α₁^2 * α₂^2 * (α₂ - α₁))
+
+    a₁ = α₁^2 * (ϕx₁ - ϕ₀ - dϕ₀ * α₂)
+    a₂ = α₂^2 * (ϕx₀ - ϕ₀ - dϕ₀ * α₁)
+    a = (a₁ - a₂) * div
+    b = (-α₁ * a₁ + α₂ * a₂) * div
+
+    return ifelse(iszero(a), dϕ₀ / 2b, (-b + sqrt(max(b^2 - 3a * dϕ₀, T(0)))) / 3a)
+end
+
+function SciMLBase.reinit!(
+        cache::BackTrackingCache; p = missing, stats = missing, kwargs...)
+    p !== missing && (cache.p = p)
+    stats !== missing && (cache.stats = stats)
+    cache.alpha = cache.initial_alpha
+    # NOTE: Don't zero out the stats here, since we don't own it
+    return cache
+end

--- a/src/backtracking.jl
+++ b/src/backtracking.jl
@@ -115,7 +115,6 @@ function CommonSolve.solve!(cache::BackTrackingCache, u, du)
     α₂ = max(α_tmp, α₂ * T(cache.alg.ρ_lo))
     ϕx₀, ϕx₁ = ϕx₁, ϕ(α₂)
 
-    # Backtrack until we satisfy sufficient decrease condition
     for _ in (iteration + 1):(cache.maxiters)
         ϕx₁ ≤ ϕ₀ + T(cache.alg.c_1) * α₂ * dϕ₀ &&
             return LineSearchSolution(α₂, ReturnCode.Success)

--- a/src/line_searches_ext.jl
+++ b/src/line_searches_ext.jl
@@ -62,37 +62,7 @@ function CommonSolve.init(
     T = promote_type(eltype(fu), eltype(u))
     autodiff = autodiff !== nothing ? autodiff : alg.autodiff
 
-    if SciMLBase.has_jvp(prob.f)
-        jvp_op = JacVecOperator(prob, fu, u; alg.autodiff)
-        vjp_op = nothing
-    elseif SciMLBase.has_vjp(prob.f)
-        vjp_op = VecJacOperator(prob, fu, u; alg.autodiff)
-        jvp_op = nothing
-    elseif u isa Number && SciMLBase.has_jac(prob.f)
-        jvp_op = JacVecOperator(prob, fu, u; alg.autodiff)
-        vjp_op = nothing
-    elseif autodiff isa ADTypes.AbstractADType
-        if ADTypes.mode(autodiff) isa ADTypes.ForwardMode
-            jvp_op = JacVecOperator(prob, fu, u; autodiff)
-            vjp_op = nothing
-        else
-            vjp_op = VecJacOperator(prob, fu, u; autodiff)
-            jvp_op = nothing
-        end
-    elseif SciMLBase.has_jac(prob.f)
-        jvp_op = JacVecOperator(prob, fu, u; autodiff)
-        vjp_op = nothing
-    else
-        error("Exhausted all possibilities for autodiff and analytic jacobian/jvp/vjp \
-               options. Either specify `autodiff` while constructing `LineSearchesJL` or \
-               pass it to `init` as a keyword argument.")
-    end
-
-    deriv_op = if jvp_op !== nothing
-        @closure (du, u, fu, p) -> dot(fu, jvp_op(du, u, p))
-    else
-        @closure (du, u, fu, p) -> dot(du, vjp_op(fu, u, p))
-    end
+    _, _, deriv_op = construct_jvp_or_vjp_operator(prob, fu, u; autodiff)
 
     @bb u_cache = similar(u)
     @bb fu_cache = similar(fu)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -10,3 +10,39 @@ end
 
 add_nf!(::Nothing, _ = 1) = nothing
 add_nf!(stats::SciMLBase.NLStats, nf = 1) = stats.nf += nf
+
+function construct_jvp_or_vjp_operator(prob::AbstractNonlinearProblem, fu, u; autodiff)
+    if SciMLBase.has_jvp(prob.f)
+        jvp_op = JacVecOperator(prob, fu, u; autodiff)
+        vjp_op = nothing
+    elseif SciMLBase.has_vjp(prob.f)
+        vjp_op = VecJacOperator(prob, fu, u; autodiff)
+        jvp_op = nothing
+    elseif u isa Number && SciMLBase.has_jac(prob.f)
+        jvp_op = JacVecOperator(prob, fu, u; autodiff)
+        vjp_op = nothing
+    elseif autodiff isa ADTypes.AbstractADType
+        if ADTypes.mode(autodiff) isa ADTypes.ForwardMode
+            jvp_op = JacVecOperator(prob, fu, u; autodiff)
+            vjp_op = nothing
+        else
+            vjp_op = VecJacOperator(prob, fu, u; autodiff)
+            jvp_op = nothing
+        end
+    elseif SciMLBase.has_jac(prob.f)
+        jvp_op = JacVecOperator(prob, fu, u; autodiff)
+        vjp_op = nothing
+    else
+        error("Exhausted all possibilities for autodiff and analytic jacobian/jvp/vjp \
+               options. Either specify `autodiff` while constructing `LineSearchesJL` or \
+               pass it to `init` as a keyword argument.")
+    end
+
+    deriv_op = if jvp_op !== nothing
+        @closure (du, u, fu, p) -> dot(fu, jvp_op(du, u, p))
+    else
+        @closure (du, u, fu, p) -> dot(du, vjp_op(fu, u, p))
+    end
+
+    return jvp_op, vjp_op, deriv_op
+end

--- a/test/custom_optimizer_tests.jl
+++ b/test/custom_optimizer_tests.jl
@@ -116,7 +116,7 @@ end
                 LiFukushimaLineSearch(),
                 NoLineSearch(0.001),
                 BackTracking(; order = Val(3), autodiff),
-                BackTracking(; order = Val(2), autodiff),
+                BackTracking(; order = Val(2), autodiff)
             )
                 fu, u, iter, alphas = gradient_descent(nlp, method; autodiff)
 
@@ -138,7 +138,7 @@ end
                 LiFukushimaLineSearch(),
                 NoLineSearch(0.001),
                 BackTracking(; order = Val(3), autodiff),
-                BackTracking(; order = Val(2), autodiff),
+                BackTracking(; order = Val(2), autodiff)
             )
                 fu, u, iter, alphas = gradient_descent(nlp, method; autodiff)
 

--- a/test/custom_optimizer_tests.jl
+++ b/test/custom_optimizer_tests.jl
@@ -61,7 +61,7 @@ end
             AutoEnzyme(), AutoReverseDiff(), AutoFiniteDiff()
         )
             @testset "method: $(nameof(typeof(method)))" for method in (
-                BackTracking(; order = 3),
+                LineSearches.BackTracking(; order = 3),
                 StrongWolfe(),
                 HagerZhang(),
                 MoreThuente()
@@ -84,8 +84,10 @@ end
             AutoForwardDiff(), AutoEnzyme(), AutoReverseDiff(), AutoFiniteDiff()
         )
             @testset "method: $(nameof(typeof(method)))" for method in (
-                BackTracking(; order = 3), StrongWolfe(),
-                HagerZhang(), MoreThuente()
+                LineSearches.BackTracking(; order = 3),
+                StrongWolfe(),
+                HagerZhang(),
+                MoreThuente()
             )
                 linesearch = LineSearchesJL(; method, autodiff)
                 fu, u, iter, alphas = gradient_descent(nlp, linesearch; autodiff)
@@ -99,7 +101,7 @@ end
 end
 
 @testitem "Native Line Search: Custom Optimizer" setup=[CustomOptimizer] begin
-    using LineSearches, SciMLBase
+    using SciMLBase
     using ADTypes, Tracker, ForwardDiff, Zygote, Enzyme, ReverseDiff, FiniteDiff
 
     @testset "OOP Problem" begin
@@ -112,7 +114,9 @@ end
         )
             @testset "method: $(nameof(typeof(method)))" for method in (
                 LiFukushimaLineSearch(),
-                NoLineSearch(0.001)
+                NoLineSearch(0.001),
+                BackTracking(; order = Val(3), autodiff),
+                BackTracking(; order = Val(2), autodiff),
             )
                 fu, u, iter, alphas = gradient_descent(nlp, method; autodiff)
 
@@ -132,7 +136,9 @@ end
         )
             @testset "method: $(nameof(typeof(method)))" for method in (
                 LiFukushimaLineSearch(),
-                NoLineSearch(0.001)
+                NoLineSearch(0.001),
+                BackTracking(; order = Val(3), autodiff),
+                BackTracking(; order = Val(2), autodiff),
             )
                 fu, u, iter, alphas = gradient_descent(nlp, method; autodiff)
 

--- a/test/root_finding_tests.jl
+++ b/test/root_finding_tests.jl
@@ -150,7 +150,7 @@ end
         )
             @testset "method: $(nameof(typeof(method)))" for method in (
                 BackTracking(; order = Val(3), autodiff),
-                BackTracking(; order = Val(2), autodiff),
+                BackTracking(; order = Val(2), autodiff)
             )
                 converged, fu, u, iter, alphas = newton_raphson(nlp, method)
 
@@ -179,7 +179,7 @@ end
         )
             @testset "method: $(nameof(typeof(method)))" for method in (
                 BackTracking(; order = Val(3), autodiff),
-                BackTracking(; order = Val(2), autodiff),
+                BackTracking(; order = Val(2), autodiff)
             )
                 converged, fu, u, iter, alphas = newton_raphson(nlp, method)
 

--- a/test/root_finding_tests.jl
+++ b/test/root_finding_tests.jl
@@ -87,7 +87,7 @@ end
             AutoEnzyme(), AutoReverseDiff(), AutoFiniteDiff()
         )
             @testset "method: $(nameof(typeof(method)))" for method in (
-                BackTracking(; order = 3),
+                LineSearches.BackTracking(; order = 3),
                 StrongWolfe(),
                 HagerZhang(),
                 MoreThuente(),
@@ -110,7 +110,7 @@ end
             AutoForwardDiff(), AutoEnzyme(), AutoReverseDiff(), AutoFiniteDiff()
         )
             @testset "method: $(nameof(typeof(method)))" for method in (
-                BackTracking(; order = 3),
+                LineSearches.BackTracking(; order = 3),
                 StrongWolfe(),
                 HagerZhang(),
                 MoreThuente(),
@@ -127,7 +127,8 @@ end
 end
 
 @testitem "Native Line Search: Newton Raphson" setup=[RootFinding] begin
-    using LineSearches, SciMLBase
+    using SciMLBase
+    using ADTypes, Tracker, ForwardDiff, Zygote, Enzyme, ReverseDiff, FiniteDiff
 
     @testset "OOP Problem" begin
         nlf(x, p) = x .^ 2 .- p
@@ -141,6 +142,21 @@ end
 
             @test fu≈[0.0, 0.0] atol=1e-1
             @test abs.(u)≈sqrt.([3.0, 3.0]) atol=1e-1
+        end
+
+        @testset for autodiff in (
+            AutoTracker(), AutoForwardDiff(), AutoZygote(),
+            AutoEnzyme(), AutoReverseDiff(), AutoFiniteDiff()
+        )
+            @testset "method: $(nameof(typeof(method)))" for method in (
+                BackTracking(; order = Val(3), autodiff),
+                BackTracking(; order = Val(2), autodiff),
+            )
+                converged, fu, u, iter, alphas = newton_raphson(nlp, method)
+
+                @test fu≈[0.0, 0.0] atol=1e-3
+                @test abs.(u)≈sqrt.([3.0, 3.0]) atol=1e-3
+            end
         end
     end
 
@@ -156,6 +172,20 @@ end
 
             @test fu≈[0.0, 0.0] atol=1e-1
             @test abs.(u)≈sqrt.([3.0, 3.0]) atol=1e-1
+        end
+
+        @testset for autodiff in (
+            AutoForwardDiff(), AutoEnzyme(), AutoReverseDiff(), AutoFiniteDiff()
+        )
+            @testset "method: $(nameof(typeof(method)))" for method in (
+                BackTracking(; order = Val(3), autodiff),
+                BackTracking(; order = Val(2), autodiff),
+            )
+                converged, fu, u, iter, alphas = newton_raphson(nlp, method)
+
+                @test fu≈[0.0, 0.0] atol=1e-3
+                @test abs.(u)≈sqrt.([3.0, 3.0]) atol=1e-3
+            end
         end
     end
 end


### PR DESCRIPTION
We use `BackTracking` in the NonlinearSolve default algorithm. With this we can finally ditch `LineSearches` dep in v4