### PR TITLE
Documentation improvements: Fix typos and inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Join the chat at https://julialang.zulipchat.com #sciml-bridged](https://img.shields.io/static/v1?label=Zulip&message=chat&color=9558b2&labelColor=389826)](https://julialang.zulipchat.com/#narrow/stream/279055-sciml-bridged)
 [![Global Docs](https://img.shields.io/badge/docs-SciML-blue.svg)](https://docs.sciml.ai/LineSearch/stable/)
 
-[![codecov](https://codecov.io/gh/SciML/LineSearch.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/SciML/LineSearch.jl)
+[![codecov](https://codecov.io/gh/SciML/LineSearch.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/SciML/LineSearch.jl)
 [![Build Status](https://github.com/SciML/LineSearch.jl/workflows/CI/badge.svg)](https://github.com/SciML/LineSearch.jl/actions?query=workflow%3ACI)
 
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor%27s%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
@@ -18,8 +18,8 @@ performance issues, please file an issue.
 
 > [!WARNING]
 > Currently this package is meant to be more developer focused. Most users are recommended
-> to use this functionality via LineSearch.jl. Support for other packages in the
-> ecosystem like Optimization.jl are planned for the future.
+> to use this functionality via NonlinearSolve.jl. Support for other packages in the
+> ecosystem like Optimization.jl is planned for the future.
 
 ## Installation
 

--- a/docs/src/api/line_searches.md
+++ b/docs/src/api/line_searches.md
@@ -1,6 +1,6 @@
 # LineSearches.jl
 
-This is a extension for importing line search algorithms from LineSearches into the SciML
+This is an extension for importing line search algorithms from LineSearches.jl into the SciML
 interface. Note that these solvers do not come by default, and thus one needs to install the
 package before using these solvers:
 

--- a/src/robust_non_monotone.jl
+++ b/src/robust_non_monotone.jl
@@ -1,5 +1,5 @@
 """
-    RobustNonMonotoneLineSearch(; gamma = 1 // 10000, sigma_0 = 1, M::Int = 10,
+    RobustNonMonotoneLineSearch(; gamma = 1 // 10000, sigma_1 = 1, M::Int = 10,
         tau_min = 1 // 10, tau_max = 1 // 2, n_exp::Int = 2, maxiters::Int = 100,
         η_strategy = (fn₁, n, uₙ, fₙ) -> fn₁ / n^2)
 


### PR DESCRIPTION
## Summary
- Fix README warning: change "LineSearch.jl" to "NonlinearSolve.jl" to match the docs/src/index.md and accurately direct users to the main package
- Fix grammar: "are planned" to "is planned" (subject-verb agreement)
- Fix codecov badge URL: change branch from "master" to "main" to match the actual default branch
- Fix grammar in line_searches.md: "a extension" to "an extension"
- Fix docstring: `RobustNonMonotoneLineSearch` signature showed `sigma_0` but the actual parameter is `sigma_1`

## Test plan
- [x] Rebuilt docs locally, no new warnings

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)