### PR TITLE
Improve explicit imports hygiene

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LineSearch"
 uuid = "87fe0de2-c867-4266-b59a-2f0a94fc965b"
-authors = ["SciML"]
 version = "0.1.5"
+authors = ["SciML"]
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -26,6 +26,7 @@ CommonSolve = "0.2.4"
 ConcreteStructs = "0.2.3"
 DifferentiationInterface = "0.6.2, 0.7"
 Enzyme = "0.13.3"
+ExplicitImports = "1.14.0"
 FastClosures = "0.3"
 FiniteDiff = "2.24.0"
 ForwardDiff = "0.10.36, 1"
@@ -48,6 +49,7 @@ julia = "1.10"
 [extras]
 DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
+ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Hwloc = "0e44f5e4-bd66-52a0-8798-143a42290a1d"
@@ -61,4 +63,4 @@ Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["DifferentiationInterface", "Enzyme", "FiniteDiff", "ForwardDiff", "Hwloc", "InteractiveUtils", "LineSearches", "NonlinearProblemLibrary", "ReTestItems", "ReverseDiff", "Test", "Tracker", "Zygote"]
+test = ["DifferentiationInterface", "Enzyme", "ExplicitImports", "FiniteDiff", "ForwardDiff", "Hwloc", "InteractiveUtils", "LineSearches", "NonlinearProblemLibrary", "ReTestItems", "ReverseDiff", "Test", "Tracker", "Zygote"]

--- a/src/LineSearch.jl
+++ b/src/LineSearch.jl
@@ -6,8 +6,7 @@ using ConcreteStructs: @concrete
 using FastClosures: @closure
 using LinearAlgebra: norm, dot
 using MaybeInplace: @bb
-using SciMLBase: SciMLBase, AbstractSciMLProblem, AbstractNonlinearProblem, ReturnCode,
-                 NonlinearProblem, NonlinearLeastSquaresProblem, NonlinearFunction
+using SciMLBase: SciMLBase, AbstractNonlinearProblem, ReturnCode, NonlinearFunction
 using SciMLJacobianOperators: VecJacOperator, JacVecOperator
 using StaticArraysCore: SArray
 

--- a/test/explicit_imports_test.jl
+++ b/test/explicit_imports_test.jl
@@ -1,0 +1,6 @@
+@testitem "Explicit Imports" begin
+    using ExplicitImports, LineSearch
+
+    @test check_no_implicit_imports(LineSearch) === nothing
+    @test check_no_stale_explicit_imports(LineSearch) === nothing
+end


### PR DESCRIPTION
## Summary

- Remove 3 stale explicit imports from SciMLBase that were imported but never used:
  - `AbstractSciMLProblem`
  - `NonlinearProblem`
  - `NonlinearLeastSquaresProblem`
- Add ExplicitImports.jl test to CI to prevent future import hygiene regressions
- Add ExplicitImports to test dependencies

The stale imports were identified using ExplicitImports.jl's `check_no_stale_explicit_imports` function.

## Test plan

- [x] ExplicitImports checks pass (`check_no_implicit_imports` and `check_no_stale_explicit_imports`)
- [ ] CI tests pass (note: existing Enzyme tests fail independently of these changes)

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)