### PR TITLE
Add test coverage for RobustNonMonotoneLineSearch

### DIFF
--- a/test/root_finding_tests.jl
+++ b/test/root_finding_tests.jl
@@ -138,6 +138,9 @@ end
         @testset "method: $(nameof(typeof(method)))" for method in (
                 LiFukushimaLineSearch(),
                 NoLineSearch(0.5),
+                RobustNonMonotoneLineSearch(),
+                RobustNonMonotoneLineSearch(; M = 1), #strictly monotonous case
+                RobustNonMonotoneLineSearch(; M = 15),
             )
             converged, fu, u, iter, alphas = newton_raphson(nlp, method)
 
@@ -168,6 +171,9 @@ end
         @testset "method: $(nameof(typeof(method)))" for method in (
                 LiFukushimaLineSearch(),
                 NoLineSearch(0.5),
+                RobustNonMonotoneLineSearch(),
+                RobustNonMonotoneLineSearch(; M = 1), #strictly monotonous case
+                RobustNonMonotoneLineSearch(; M = 15),
             )
             converged, fu, u, iter, alphas = newton_raphson(nlp, method)
 


### PR DESCRIPTION
### RobustNonMonotoneLineSearch was implemented in src/ but had no  coverage in the native test suite.
Added robustnonmonotonelinesearch tests to root_finding_tests.jl. Did not add robustnonmonotonelinesearch function to custom_optimizer_tests.jl because it throws an error. (probably because it does not converge within the set tolerance level for rosenbrock functions).

