### PR TITLE
Migrate CI to centralized SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,12 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"
       - "/docs"
       - "/test"
+      - "/test/enzyme"
     schedule:
       interval: "daily"
     groups:

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -11,28 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@latest
-        with:
-          version: '1'
-      - name: Install dependencies
-        run: |
-          import Pkg
-          Pkg.Registry.update()
-          Pkg.develop(Pkg.PackageSpec(path=pwd()))
-          Pkg.instantiate()
-        shell: julia --color=yes --project=docs/ {0}
-      - name: Build and deploy
-        env:
-          JULIA_DEBUG: "Documenter"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }} # For authentication with SSH deploy key
-        run: julia --project=docs/ --code-coverage=user --color=yes docs/make.jl
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v6
-        with:
-          files: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+    uses: "SciML/.github/.github/workflows/documentation.yml@v1"
+    with:
+      debug-documenter: true
+    secrets: "inherit"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -13,20 +13,9 @@ on:
 jobs:
   test:
     if: false
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      skip: "Pkg,TOML"
+      allow-reresolve: false
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,5 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,5 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.26.0 
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -18,38 +18,26 @@ concurrency:
 
 jobs:
   tests:
-    name: "${{ matrix.group }} - Julia ${{ matrix.version }}"
-    runs-on: ubuntu-latest
+    name: "Tests"
     strategy:
       fail-fast: false
       matrix:
         version:
-          - '1'
-          - 'lts'
+          - "1"
+          - "lts"
         group:
           - Core
           - LineSearchesJL
           - QA
         exclude:
           # QA tests only run on latest stable Julia
-          - version: 'lts'
+          - version: "lts"
             group: QA
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: ${{ matrix.version }}
-      - uses: julia-actions/cache@v3
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        env:
-          GROUP: ${{ matrix.group }}
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v6
-        with:
-          files: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
+    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+    with:
+      julia-version: "${{ matrix.version }}"
+      group: "${{ matrix.group }}"
+    secrets: "inherit"
 
   enzyme:
     name: "Enzyme Tests"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas

This PR normalizes the CI of LineSearch.jl to the SciML centralized reusable workflows in `SciML/.github` (every caller pinned `@v1`, `secrets: inherit`). Existing behavior and test matrices are preserved exactly.

## Workflows converted
- **Tests.yml** -> matrix of `tests.yml@v1` callers. Preserves the exact matrix: `version` ∈ {`1`, `lts`} × `group` ∈ {`Core`, `LineSearchesJL`, `QA`}, excluding `QA` on `lts`. Coverage stays on (caller default). The non-standard **Enzyme Tests** job (separate `test/enzyme` environment, custom `Pkg.develop`/`instantiate` + `test/enzyme/runtests.jl`) is **kept as a regular step-based job in the same file** since the reusable tests workflow cannot reproduce it.
- **Documentation.yml** -> `documentation.yml@v1` caller with `debug-documenter: true` (original set `JULIA_DEBUG=Documenter`). Coverage stays on (caller default, matching original `--code-coverage=user`).
- **Downgrade.yml** -> `downgrade.yml@v1` caller. **Kept disabled** (`if: false`, as in the original), preserving `julia-version: "1.10"`, `skip: "Pkg,TOML"`, `allow-reresolve: false`.
- **FormatCheck.yml** -> `runic.yml@v1` caller.
- **SpellCheck.yml** -> `spellcheck.yml@v1` caller.

## Runic
The repo **already ran Runic** (via `fredrikekre/runic-action`). I ran `Runic.main(["--check", "."])` (Runic v1.7.0) locally and it passed with no changes, so **no formatting commit was needed**.

## Spellcheck / typos
Ran `typos` locally — **no typos found**, no `_typos.toml` needed.

## Dependabot / CompatHelper
- No `CompatHelper.yml` existed, so nothing to remove.
- **dependabot.yml**: removed the `crate-ci/typos` ignore block (standing policy: keep everything current). Preserved the existing `julia` directories (`/`, `/docs`, `/test`) and **added `/test/enzyme`** (it has its own `Project.toml`). The `github-actions` block (`directory: "/"`, weekly) and the `julia` block (daily, `all-julia-packages` group) are otherwise unchanged.
- **TagBot.yml** left unchanged.

## Heads-up
- **Branch protection / required status checks must be updated.** The job/check names change under the reusable workflows (e.g. tests now report as `Tests / Tests` rather than `Core - Julia 1`), so any required-status-check names in branch protection need updating to match.
- Minor behavior diff: the original Documentation workflow used `fail_ci_if_error: true` on codecov; the centralized `documentation.yml@v1` does not set that flag (defaults to false). This makes the docs build slightly more tolerant of codecov upload failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)