### PR TITLE
Drop now-invalid allow-reresolve input from downgrade workflow(s)

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -17,5 +17,4 @@ jobs:
       julia-version: "1.10"
       skip: "Pkg,TOML"
       group: "All"
-      allow-reresolve: false
     secrets: "inherit"


### PR DESCRIPTION
## What

Remove the now-invalid `allow-reresolve:` input from the downgrade workflow(s).

The centralized `SciML/.github` downgrade workflows (`downgrade.yml` and
`sublibrary-downgrade.yml`) are being changed to **always** use
`allow_reresolve: false` and to drop the `allow-reresolve` `workflow_call`
input entirely (see SciML/.github#71). Once that merges and `@v1` is retagged,
any caller still passing `allow-reresolve:` would fail with an invalid-input
error. This PR removes that line so this repo keeps working.---

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>