### PR TITLE
Canonical CI: grouped-tests.yml + root test/test_groups.toml

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -18,25 +18,7 @@ concurrency:
 
 jobs:
   tests:
-    name: "Tests"
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - "1"
-          - "lts"
-        group:
-          - Core
-          - LineSearchesJL
-          - QA
-        exclude:
-          # QA tests only run on latest stable Julia
-          - version: "lts"
-            group: QA
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      julia-version: "${{ matrix.version }}"
-      group: "${{ matrix.group }}"
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     secrets: "inherit"
 
   enzyme:

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,0 +1,8 @@
+[Core]
+versions = ["1", "lts"]
+
+[LineSearchesJL]
+versions = ["1", "lts"]
+
+[QA]
+versions = ["1"]


### PR DESCRIPTION
## Summary

Converts the root **Tests.yml** test workflow to the canonical thin caller and moves the test matrix into a root `test/test_groups.toml`.

- The matrix `tests:` job is replaced with:
  ```yaml
  jobs:
    tests:
      uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
      secrets: "inherit"
  ```
- The `group × version` matrix now lives in `test/test_groups.toml`:
  ```toml
  [Core]
  versions = ["1", "lts"]

  [LineSearchesJL]
  versions = ["1", "lts"]

  [QA]
  versions = ["1"]
  ```
- `on:`, `concurrency:`, the workflow `name:`, the separate `enzyme:` job, and every other workflow are left untouched.
- No `with:` overrides are needed: `runtests.jl` already reads the default `GROUP` env var (ReTestItems tag dispatch), check-bounds/coverage stay at defaults, no apt packages.

## Matrix match

`compute_affected_sublibraries.jl --root-matrix` (run with Julia 1.11) emits exactly the same `(group, version)` set as the previous hand-maintained matrix — 5 jobs:

| Group | Version |
|---|---|
| Core | 1 |
| Core | lts |
| LineSearchesJL | 1 |
| LineSearchesJL | lts |
| QA | 1 |

(The old matrix excluded `lts × QA`; the TOML reproduces that by listing QA on `["1"]` only.) No `os` field — Linux-only, as before.

## Metadata

Root `Project.toml` already has `[compat] julia = "1.10"` (LTS floor) and a `[compat]` entry for every `[extras]` dependency, so no pre-emptive metadata fixes were required.

## QA note

This package's `QA` group already existed and runs via ReTestItems tags (`:qa`, currently ExplicitImports) inside the main test environment — not a separate `test/qa/` subproject. The conversion preserves that architecture. QA continues to run on Julia `1` only. Any QA findings surfaced in CI will be triaged in a follow-up.

---

Static verification only: TOML + YAML parse cleanly and the root-matrix script reproduces the old matrix. Tests/Aqua/JET were **not** run locally; they will run in CI.

Ignore until reviewed by @ChrisRackauckas.