### PR TITLE
Bump version to 0.1.11

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LineSearch"
 uuid = "87fe0de2-c867-4266-b59a-2f0a94fc965b"
-version = "0.1.10"
+version = "0.1.11"
 authors = ["SciML"]
 
 [deps]


### PR DESCRIPTION
Automated patch version bump (0.1.10 -> 0.1.11) to release unreleased commits on `main` via JuliaRegistrator.