### PR TITLE
Release prep: bump LineSearch to 0.1.12

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LineSearch"
 uuid = "87fe0de2-c867-4266-b59a-2f0a94fc965b"
-version = "0.1.11"
+version = "0.1.12"
 authors = ["SciML"]
 
 [deps]


### PR DESCRIPTION
Patch release for accumulated docstring/QA/test scaffolding changes since 0.1.11 (no functional/API changes).