### PR TITLE
Run downgrade workflow on main

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -7,7 +7,7 @@ on:
       - 'docs/**'
   push:
     branches:
-      - master
+      - main
     paths-ignore:
       - 'docs/**'
 jobs:


### PR DESCRIPTION
## Summary

- run the downgrade workflow after pushes to the repository's actual default branch, `main`
- leave the existing pull-request trigger and reusable workflow unchanged

The workflow currently listens for pushes to `master`, so it has no completed
run at the current default-branch SHA.

## Local validation

- exact Julia 1.10 downgrade action, build, and locked `All` test replay: passed
- Core custom optimizer tests: 144/144 passed
- Core root-finding tests: 85/85 passed
- LineSearchesJL custom optimizer tests: 96/96 passed
- LineSearchesJL root-finding tests: 80/80 passed
- `actionlint .github/workflows/Downgrade.yml`: passed
- Runic 1.7 over all 20 Julia files: passed
- `git diff --check`: passed

Ignore this PR until it has been reviewed by @ChrisRackauckas.
