### PR TITLE
Use standard SciMLTesting QA docs check

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,3 +1,3 @@
 using SciMLTesting, LineSearch
 
-run_qa(LineSearch; explicit_imports = true, api_docs_kwargs = (; rendered = true))
+run_qa(LineSearch; explicit_imports = true)


### PR DESCRIPTION
Removes the repository-specific rendered API-docs override. LineSearch already requires SciMLTesting `2.1+`; the standard QA configuration now owns this check.

Validated with Runic, the standard QA environment, and `Pkg.test()`.

Ignore until reviewed by @ChrisRackauckas.