### PR TITLE
Use SciMLTesting default QA checks

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,3 +1,3 @@
 using SciMLTesting, LineSearch
 
-run_qa(LineSearch; explicit_imports = true, api_docs_kwargs = (; rendered = true))
+run_qa(LineSearch)


### PR DESCRIPTION
Removes redundant `explicit_imports = true` and rendered-public-doc QA overrides. SciMLTesting 2.3 enables both checks by default.

Local verification: `Pkg.test()` completed using SciMLTesting 2.3.0; Runic check passed.

Ignore until reviewed by @ChrisRackauckas.