### PR TITLE
Make the QA group scan the LineSearches extension

### DIFF
--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,10 +1,12 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 LineSearch = "87fe0de2-c867-4266-b59a-2f0a94fc965b"
+LineSearches = "d3d80556-e9d4-5f37-9878-2ab0fcc64255"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Aqua = "0.8"
+LineSearches = "7.3.0"
 SciMLTesting = "2.4"
 Test = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,3 +1,7 @@
 using SciMLTesting, LineSearch
 
+# ExplicitImports only sees an extension module once its trigger package is loaded, so
+# load the weakdeps here to bring LineSearchLineSearchesExt into the QA scan.
+using LineSearches
+
 run_qa(LineSearch)


### PR DESCRIPTION
## Problem

`SciMLTesting.run_qa` runs ExplicitImports' checks on the package. ExplicitImports *does* know about extensions — its `_find_submodules` reads the `[extensions]` table out of `Project.toml` — but it skips any extension whose module does not exist:

```julia
ext_mod = Base.get_extension(mod, Symbol(ext))
ext_mod === nothing && continue
```

An extension module only exists once its trigger weakdep is loaded. The QA environment loaded no weakdeps, so `LineSearchLineSearchesExt` was never scanned by QA at all.

## Change

* `test/qa/Project.toml`: add `LineSearches` under `[deps]` (same UUID as the root `[weakdeps]` entry) with a `[compat]` bound mirroring the root package's (`7.3.0`).
* `test/qa/qa.jl`: `using LineSearches` before `run_qa`, with a comment explaining why.

## Coverage

* **Now scanned:** `LineSearchLineSearchesExt` (the package's only extension).
* **Still unscanned:** none.

Verified the extension is genuinely in the scan set rather than just assuming it — with the change, `ExplicitImports.explicit_imports(LineSearch)` returns entries for both `LineSearch` and `LineSearchLineSearchesExt`, and `Base.get_extension(LineSearch, :LineSearchLineSearchesExt)` is non-`nothing` inside the test env.

## Ignore entries added

**None.** The newly-scanned extension is clean — `improper_qualified_accesses` and `improper_explicit_imports` both return empty for `LineSearchLineSearchesExt`. No extension source changes were needed either.

## Local QA result

```
$ GROUP=QA julia --project=. -e 'using Pkg; Pkg.test()'
...
Precompiling packages...
  11201.3 ms  ✓ LineSearch
   1594.5 ms  ✓ LineSearch → LineSearchLineSearchesExt
Test Summary: | Pass  Total   Time
QA/qa.jl      |   20     20  33.1s
     Testing LineSearch tests passed
```

Note the `LineSearch → LineSearchLineSearchesExt` precompile line, which does not appear on `main`'s QA run — that is the extension being brought into the environment.

---

Please ignore this PR until reviewed by @ChrisRackauckas.