### PR TITLE
Assert the LineSearches extension actually loaded in QA

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,7 +1,13 @@
-using SciMLTesting, LineSearch
+using SciMLTesting, LineSearch, Test
 
 # ExplicitImports only sees an extension module once its trigger package is loaded, so
 # load the weakdeps here to bring LineSearchLineSearchesExt into the QA scan.
 using LineSearches
+
+# ExplicitImports silently skips an extension that fails to load, so assert the
+# extension modules actually exist rather than trusting a green run_qa.
+@testset "Extensions loaded" begin
+    @test Base.get_extension(LineSearch, :LineSearchLineSearchesExt) !== nothing
+end
 
 run_qa(LineSearch)


### PR DESCRIPTION
Follow-up to #89, which merged before this commit landed on the branch.

## Problem

#89 made QA scan `LineSearchLineSearchesExt` by loading the trigger weakdep. But ExplicitImports skips an extension whose module does not exist, and it does so **silently**:

```julia
ext_mod = Base.get_extension(mod, Symbol(ext))
ext_mod === nothing && continue
```

The extension is dropped from the scan set and every check still reports clean. No warning, no failing test. So a future change that stops the extension from loading reverts #89 invisibly — QA stays green while extension coverage drops back to zero.

## Change

Assert the extension module exists, rather than trusting a green `run_qa`:

```julia
@testset "Extensions loaded" begin
    @test Base.get_extension(LineSearch, :LineSearchLineSearchesExt) !== nothing
end
```

## Why this is not ceremony

A green QA summary is not evidence the extension was scanned. `run_qa` emits a fixed number of `@test`s; each ExplicitImports check folds its per-submodule results into one assertion, so the count is identical whether or not the extension is in the scan set. Before #89 this suite was `20/20 Pass`; after #89 it was still `20/20 Pass` with the extension scanned. The summary could not distinguish the two.

I verified the guard catches the real regression rather than being a tautology, by commenting out the `using LineSearches` line and re-running:

```
Extensions loaded: Test Failed at test/qa/qa.jl:10
  Expression: Base.get_extension(LineSearch, :LineSearchLineSearchesExt) !== nothing

Test Summary:       | Pass  Fail  Total   Time
QA/qa.jl            |   20     1     21  39.2s
  Extensions loaded |          1      1   3.4s
```

All 20 ExplicitImports/Aqua checks still pass with coverage silently at zero. Only the guard catches it.

(A hard precompile failure inside the extension is already caught loudly by `using LineSearches` itself. This guard covers the quiet case, where the module simply is not there.)

## Local QA result

```
$ GROUP=QA julia --project=. -e 'using Pkg; Pkg.test()'
...
Test Summary: | Pass  Total   Time
QA/qa.jl      |   21     21  35.7s
     Testing LineSearch tests passed
```

Run on this branch, which is `main` (including the merged #89) plus this one commit.

---

Please ignore this PR until reviewed by @ChrisRackauckas.