### PR TITLE
Use eltype(prob.u0) for StrongWolfe OptimizationProblem init

### DIFF
--- a/src/strong_wolfe.jl
+++ b/src/strong_wolfe.jl
@@ -111,7 +111,7 @@ function CommonSolve.init(
              `prob.f.grad` (out-of-place) on the OptimizationFunction."
         )
     )
-    T = promote_type(eltype(fu), eltype(u))
+    T = eltype(prob.u0)
     return StaticStrongWolfeLineSearchCache(
         prob.f, grad, prob.p,
         T(alg.c1), T(alg.c2), T(alg.α_init), T(alg.α_max),


### PR DESCRIPTION
Match SciML convention: line-search parameter types come from the problem state, not from the fu/u arguments passed to init.

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
